### PR TITLE
Update to transfer of operator

### DIFF
--- a/contracts/market_place.sol
+++ b/contracts/market_place.sol
@@ -62,7 +62,7 @@ contract MarketPlace{
     function changeOperator(address _newOperator) external {
         require(msg.sender == operator,"only the operator can change the current operator");
         address previousOperator = operator;
-        operator = msg.sender;
+        operator = _newOperator;
         emit OperatorChanged(previousOperator, operator);
     }
 


### PR DESCRIPTION
As it stands, this requires  msg.sender is operator, then sets operator to msg.sender. This does not make sense and I doubt it was intentional. You probably wanted to set it to _newOperator. Which is asked for but never used.